### PR TITLE
Explicitly mark certain transforms as ResultTransforms

### DIFF
--- a/girder_worker_utils/transform.py
+++ b/girder_worker_utils/transform.py
@@ -5,9 +5,6 @@ import six
 
 @six.add_metaclass(abc.ABCMeta)
 class Transform(object):
-    def __init__(self, *args, **kwargs):
-        pass
-
     def _repr_model_(self):
         """Return as representation of the object suitable for storing in mongo.
 
@@ -23,4 +20,11 @@ class Transform(object):
 
     @abc.abstractmethod
     def transform(self):
+        pass
+
+
+@six.add_metaclass(abc.ABCMeta)
+class ResultTransform(Transform):
+    @abc.abstractmethod
+    def transform(self, data):
         pass

--- a/girder_worker_utils/transforms/girder_io.py
+++ b/girder_worker_utils/transforms/girder_io.py
@@ -4,7 +4,7 @@ import tempfile
 
 from girder_client import GirderClient
 
-from ..transform import Transform
+from ..transform import ResultTransform, Transform
 
 
 class GirderClientTransform(Transform):
@@ -20,6 +20,10 @@ class GirderClientTransform(Transform):
                 self.gc = gc
         except ImportError:
             self.gc = None
+
+
+class GirderClientResultTransform(ResultTransform, GirderClientTransform):
+    pass
 
 
 class GirderFileId(GirderClientTransform):
@@ -57,7 +61,7 @@ class GirderItemMetadata(GirderClientTransform):
         return data
 
 
-class GirderUploadToItem(GirderClientTransform):
+class GirderUploadToItem(GirderClientResultTransform):
     def __init__(self, _id, delete_file=False, **kwargs):
         super(GirderUploadToItem, self).__init__(**kwargs)
         self.item_id = _id


### PR DESCRIPTION
This explicitly creates a difference between Transforms (e.g inputs to a task)  and ResultTransforms (e.g outputs of a task).  The primary difference is that Result.Transform.transform()  takes an argument which is the return value of a task.  

This is accomplished by having ResultTransform inherit from Transform and redeclare the abstract method to include a data argument.  GirderClientResultTransform is also implemented by orchestrating the method resolution order.

This is mostly a cosmetic change as Python does not enforce abstract method function signatures. It does however provide a place to add result transform specific methods. 
