### PR TITLE
Add tee utilities

### DIFF
--- a/demo/gw_utils_demo_app/transform.py
+++ b/demo/gw_utils_demo_app/transform.py
@@ -11,7 +11,7 @@ class Capitalize(Transform):
 class RaiseException(Transform):
 
     def transform(self):
-        raise DecodeError("Some kind of Error")
+        raise DecodeError('Some kind of Error')
 
 
 class Reverse(Transform):

--- a/girder_worker_utils/tee.py
+++ b/girder_worker_utils/tee.py
@@ -13,7 +13,13 @@ def tee_stdout(cls):
         sys.stdout = stream
         return old
 
+    def _get_stdout():
+        """Return the object that sys.stdout points too."""
+        return sys.stdout
+
     cls._set_stream = staticmethod(_set_stdout)
+    cls._get_stream = staticmethod(_get_stdout)
+
     return cls
 
 
@@ -29,41 +35,120 @@ def tee_stderr(cls):
         sys.stderr = stream
         return old
 
+    def _get_stderr():
+        """Return the object that sys.stderr points too."""
+        return sys.stderr
+
     cls._set_stream = staticmethod(_set_stderr)
+    cls._get_stream = staticmethod(_get_stderr)
     return cls
 
 
 class Tee(object):
+    """Implements a context manager for intercepting write streams.
+
+    This object is loosely inspired by the classic GNU utility
+    tee(1). It allows a developer to intercept stream write() calls,
+    act on that data, and then passes that data through to the
+    original stream object.
+
+    Consider the case of sys.stdout; which is like a global 'pointer'
+    to a writeable object. It may be reassigned to other writable
+    objects to 'hijack' the effects of print() or sys.stdout.write()
+    statements. This is somewhat problematic, as we may want to write
+    both to the new object, and to the previous value of sys.stdout
+    (e.g. a pseudo-tty).
+
+    The Tee object implements a basic, singly-linked list of writable
+    objects. When a process calls print(), data is written to
+    sys.stdout, which (if it is a Tee object) calls write(), and then
+    passes the data to its downstream object for processing. This
+    process continues until either it encounters a non-Tee object
+    (e.g. the open stdout file object) or a Tee that does not pass
+    data through to its downstream connections.
+
+    """
+
+    # Note that by abstracting over the stream via the _set_stream and
+    # _get_stream methods we can use decorators like tee_stdout and
+    # tee_stderr to implement common functionality in a base class and
+    # then decorate derived subclasses which handle specific stream
+    # functionality. See TeeStdOut and TeeStdErr.
     @staticmethod
     def _set_stream(stream):
+        """Set a stream 'pointer' (e.g. sys.stdout) to a new writeable object.
+
+        This function should set a known global pointer to a stream
+        object (e.g sys.stdout) to a new writable object. it should
+        return the old value of the pointer so that it may be stored
+        in the '_downstream' attribute of the Tee object.
+
+        """
+        pass
+
+    @staticmethod
+    def _get_stream():
+        """Get the stream 'pointer' this object is Teeing.
+
+        For example, if this object was Teeing sys.stdout, it would
+        return the current value of sys.stdout.
+        """
         pass
 
     def __init__(self, pass_through=True):
         self.pass_through = pass_through
-        self._original = self._set_stream(self)
+        self._downstream = self._set_stream(self)
 
     def __enter__(self):
         return self
 
     def __exit__(self, *args, **kwargs):
-        pass
+        self.reset()
 
-    def __del__(self):
-        # Clean set the stream back to the original on deletion. This
-        # prevents losing the original stream object, and also makes
-        # subclasses very ammenable to contextmanagers.
-        self._set_stream(self._original)
+    def reset(self):
+        """Remove the current Tee object from the list of Tee objects.
+
+        This removes the current object from the linked list of Tee
+        objects associated with the stream returned by
+        self._get_stream().
+
+        Consider the case of several chained Tee objects (e.g. t1, t2,
+        t3) where the original '<stdout>' open file is downstream from
+        t1, t1 is downstream from t2, and t2 is downstream from t3:
+
+        t3 => t2 => t1 => <open file '<stdout>', ...>
+        ^
+        sys.stdout
+
+        sys.stdout points to t3. If we call t1.reset() it would be
+        incorrect to set sys.stdout to the <open file ...> (t1's
+        downstream). Instead sys.stdout must continue to point to t3
+        and t2._downstream should be updated to point to the <open
+        file ...>. This ensures that Tee objects may leave the chain
+        as-needed without losing connections.
+
+        """
+        prev, cur = None, self._get_stream()
+
+        if cur == self:
+            self._set_stream(self._downstream)
+            return
+
+        while hasattr(cur, '_downstream'):
+            prev, cur = cur, cur._downstream
+            if cur == self:
+                prev._downstream = cur._downstream
 
     def __getattr__(self, attr):
         return getattr(self._original, attr)
 
     def write(self, *args, **kwargs):
         if self.pass_through:
-            self._original.write(*args, **kwargs)
+            self._downstream.write(*args, **kwargs)
 
     def flush(self, *args, **kwargs):
         if self.pass_through:
-            self._original.flush(*args, **kwargs)
+            self._downstream.flush(*args, **kwargs)
 
 
 @tee_stdout

--- a/girder_worker_utils/tee.py
+++ b/girder_worker_utils/tee.py
@@ -1,0 +1,71 @@
+import abc
+import sys
+
+import six
+
+
+def _set_stdout(stream):
+    """Set sys.stdout to a new file-like object.
+
+    This is a private function for re-assigning sys.stdout. It returns
+    the old value of sys.stdout.
+
+    """
+    old = sys.stdout
+    sys.stdout = stream
+    return old
+
+
+def _set_stderr(stream):
+    """Set sys.stderr to a new file-like object.
+
+    This is a private function for re-assigning sys.stderr. It returns
+    the old value of sys.stderr.
+
+    """
+    old = sys.stderr
+    sys.stderr = stream
+    return old
+
+
+@six.add_metaclass(abc.ABCMeta)
+class Tee(object):
+    @staticmethod
+    @abc.abstractmethod
+    def set_stream(stream):
+        pass
+
+    def __init__(self, pass_through=True):
+        self.pass_through = pass_through
+        self._original = self.set_stream(self)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args, **kwargs):
+        pass
+
+    def __del__(self):
+        # Clean set the stream back to the original on deletion. This
+        # prevents losing the original stream object, and also makes
+        # subclasses very ammenable to contextmanagers.
+        self.set_stream(self._original)
+
+    def __getattr__(self, attr):
+        return getattr(self._original, attr)
+
+    def write(self, *args, **kwargs):
+        if self.pass_through:
+            self._original.write(*args, **kwargs)
+
+    def flush(self, *args, **kwargs):
+        if self.pass_through:
+            self._original.flush(*args, **kwargs)
+
+
+class TeeStdOut(Tee):
+    set_stream = staticmethod(_set_stdout)
+
+
+class TeeStdErr(Tee):
+    set_stream = staticmethod(_set_stderr)

--- a/girder_worker_utils/tee.py
+++ b/girder_worker_utils/tee.py
@@ -1,43 +1,46 @@
-import abc
 import sys
 
-import six
+
+def tee_stdout(cls):
+    def _set_stdout(stream):
+        """Set sys.stdout to a new file-like object.
+
+        This is a private function for re-assigning sys.stdout. It returns
+        the old value of sys.stdout.
+
+        """
+        old = sys.stdout
+        sys.stdout = stream
+        return old
+
+    cls._set_stream = staticmethod(_set_stdout)
+    return cls
 
 
-def _set_stdout(stream):
-    """Set sys.stdout to a new file-like object.
+def tee_stderr(cls):
+    def _set_stderr(stream):
+        """Set sys.stderr to a new file-like object.
 
-    This is a private function for re-assigning sys.stdout. It returns
-    the old value of sys.stdout.
+        This is a private function for re-assigning sys.stderr. It returns
+        the old value of sys.stderr.
 
-    """
-    old = sys.stdout
-    sys.stdout = stream
-    return old
+        """
+        old = sys.stderr
+        sys.stderr = stream
+        return old
 
-
-def _set_stderr(stream):
-    """Set sys.stderr to a new file-like object.
-
-    This is a private function for re-assigning sys.stderr. It returns
-    the old value of sys.stderr.
-
-    """
-    old = sys.stderr
-    sys.stderr = stream
-    return old
+    cls._set_stream = staticmethod(_set_stderr)
+    return cls
 
 
-@six.add_metaclass(abc.ABCMeta)
 class Tee(object):
     @staticmethod
-    @abc.abstractmethod
-    def set_stream(stream):
+    def _set_stream(stream):
         pass
 
     def __init__(self, pass_through=True):
         self.pass_through = pass_through
-        self._original = self.set_stream(self)
+        self._original = self._set_stream(self)
 
     def __enter__(self):
         return self
@@ -49,7 +52,7 @@ class Tee(object):
         # Clean set the stream back to the original on deletion. This
         # prevents losing the original stream object, and also makes
         # subclasses very ammenable to contextmanagers.
-        self.set_stream(self._original)
+        self._set_stream(self._original)
 
     def __getattr__(self, attr):
         return getattr(self._original, attr)
@@ -63,9 +66,11 @@ class Tee(object):
             self._original.flush(*args, **kwargs)
 
 
+@tee_stdout
 class TeeStdOut(Tee):
-    set_stream = staticmethod(_set_stdout)
+    pass
 
 
+@tee_stderr
 class TeeStdErr(Tee):
-    set_stream = staticmethod(_set_stderr)
+    pass

--- a/girder_worker_utils/tee.py
+++ b/girder_worker_utils/tee.py
@@ -2,6 +2,13 @@ import sys
 
 
 def tee_stdout(cls):
+    """Decorate a Tee class giving it access to sys.stdout.
+
+    This function is intended to decorate a class that subclasses the
+    Tee object. It assigns the _set_stream and _get_stream methods on
+    the cls in such a way that the class's write() method will recieve
+    data passed to sys.stdout.
+    """
     def _set_stdout(stream):
         """Set sys.stdout to a new file-like object.
 
@@ -24,6 +31,13 @@ def tee_stdout(cls):
 
 
 def tee_stderr(cls):
+    """Decorate a Tee class giving it access to sys.stderr.
+
+    This function is intended to decorate a class that subclasses the
+    Tee object. It assigns the _set_stream and _get_stream methods on
+    the cls in such a way that the class's write() method will recieve
+    data passed to sys.stderr.
+    """
     def _set_stderr(stream):
         """Set sys.stderr to a new file-like object.
 

--- a/girder_worker_utils/tests/tee_test.py
+++ b/girder_worker_utils/tests/tee_test.py
@@ -110,6 +110,25 @@ def test_tee_multiple_tee_objects_downstream():
     assert sys.stdout._downstream._downstream._downstream == original_stdout
 
 
+def test_tee_multiple_tee_objects_each_recieves_write(capfd):
+    original_stdout = sys.stdout
+    o1, o2, o3 = TeeCapture(), TeeCapture(), TeeCapture()
+
+    assert sys.stdout == o3
+    assert o3._downstream == o2
+    assert o2._downstream == o1
+    assert o1._downstream == original_stdout
+
+    print('Test String')
+
+    assert o3.buf == 'Test String\n'
+    assert o2.buf == 'Test String\n'
+    assert o1.buf == 'Test String\n'
+
+    out, err = capfd.readouterr()
+    assert out == 'Test String\n'
+
+
 def test_tee_multiple_tee_objects_reset_o1():
     original_stdout = sys.stdout
     o1, o2, o3 = TeeCapture(), TeeCapture(), TeeCapture()

--- a/girder_worker_utils/tests/tee_test.py
+++ b/girder_worker_utils/tests/tee_test.py
@@ -82,3 +82,96 @@ def test_tee_overwrites_write_pass_through_false(capfd):
 
     out, err = capfd.readouterr()
     assert out == ''
+
+
+def test_tee_reset_function_resets(capfd):
+    original_stdout = sys.stdout
+
+    o = TeeCapture()
+
+    print('Test String')
+    out, err = capfd.readouterr()
+
+    assert o.buf == 'Test String\n'
+    assert out == 'Test String\n'
+
+    o.reset()
+
+    assert sys.stdout == original_stdout
+
+
+def test_tee_multiple_tee_objects_downstream():
+    original_stdout = sys.stdout
+    o1, o2, o3 = TeeCapture(), TeeCapture(), TeeCapture()
+
+    assert sys.stdout == o3
+    assert sys.stdout._downstream == o2
+    assert sys.stdout._downstream._downstream == o1
+    assert sys.stdout._downstream._downstream._downstream == original_stdout
+
+
+def test_tee_multiple_tee_objects_reset_o1():
+    original_stdout = sys.stdout
+    o1, o2, o3 = TeeCapture(), TeeCapture(), TeeCapture()
+
+    o1.reset()
+
+    assert o3._downstream == o2
+    assert o2._downstream == original_stdout
+
+
+def test_tee_multiple_tee_objects_reset_o2():
+    original_stdout = sys.stdout
+    o1, o2, o3 = TeeCapture(), TeeCapture(), TeeCapture()
+
+    o2.reset()
+
+    assert o3._downstream == o1
+    assert o1._downstream == original_stdout
+
+
+def test_tee_multiple_tee_objects_reset_o3():
+    original_stdout = sys.stdout
+    o1, o2, o3 = TeeCapture(), TeeCapture(), TeeCapture()
+
+    o3.reset()
+
+    assert sys.stdout == o2
+    assert o2._downstream == o1
+    assert o1._downstream == original_stdout
+
+
+def test_tee_multiple_tee_objects_reset_o3_then_o1():
+    original_stdout = sys.stdout
+    o1, o2, o3 = TeeCapture(), TeeCapture(), TeeCapture()
+
+    o3.reset()
+
+    assert sys.stdout == o2
+    assert o2._downstream == o1
+    assert o1._downstream == original_stdout
+
+    o1.reset()
+
+    assert sys.stdout == o2
+    assert o2._downstream == original_stdout
+
+
+def test_tee_multiple_tee_objects_reset_o3_then_o1_then_o2():
+    original_stdout = sys.stdout
+    o1, o2, o3 = TeeCapture(), TeeCapture(), TeeCapture()
+
+    o3.reset()
+
+    assert sys.stdout == o2
+    assert o2._downstream == o1
+    assert o1._downstream == original_stdout
+
+    o1.reset()
+
+    assert sys.stdout == o2
+    assert o2._downstream == original_stdout
+
+    o2.reset()
+
+    assert sys.stdout == original_stdout

--- a/girder_worker_utils/tests/tee_test.py
+++ b/girder_worker_utils/tests/tee_test.py
@@ -1,0 +1,83 @@
+import sys
+
+from girder_worker_utils.tee import TeeStdErr, TeeStdOut
+
+
+class TeeCapture(TeeStdOut):
+    def __init__(self, *args, **kwargs):
+        self.buf = ''
+        super(TeeCapture, self).__init__(*args, **kwargs)
+
+    def write(self, message, **kwargs):
+        self.buf += message
+        super(TeeCapture, self).write(message, **kwargs)
+
+
+def test_tee_sys_write_stdout(capfd):
+    with TeeStdOut():
+        sys.stdout.write('Test String')
+        sys.stdout.flush()
+
+    out, err = capfd.readouterr()
+    assert out == 'Test String'
+
+
+def test_tee_print_stdout(capfd):
+    with TeeStdOut():
+        print('Test String')
+
+    out, err = capfd.readouterr()
+    assert out == 'Test String\n'
+
+
+def test_tee_stdout_sys_write_pass_through_false(capfd):
+    with TeeStdOut(pass_through=False):
+        sys.stdout.write('Test String')
+        sys.stdout.flush()
+
+    out, err = capfd.readouterr()
+    assert out == ''
+
+
+def test_tee_stdout_print_pass_through_false(capfd):
+    with TeeStdOut(pass_through=False):
+        print('Test String')
+
+    out, err = capfd.readouterr()
+    assert out == ''
+
+
+def test_tee_sys_write_stderr(capfd):
+    with TeeStdErr():
+        sys.stderr.write('Test String')
+        sys.stderr.flush()
+
+    out, err = capfd.readouterr()
+    assert err == 'Test String'
+
+
+def test_tee_stderr_sys_write_pass_through_false(capfd):
+    with TeeStdErr(pass_through=False):
+        sys.stderr.write('Test String')
+        sys.stderr.flush()
+
+    out, err = capfd.readouterr()
+    assert err == ''
+
+
+def test_tee_overwrites_write(capfd):
+    with TeeCapture() as o:
+        print('Test String')
+        assert o.buf == 'Test String\n'
+
+    out, err = capfd.readouterr()
+    assert out == 'Test String\n'
+
+
+def test_tee_overwrites_write_pass_through_false(capfd):
+    with TeeCapture(pass_through=False) as o:
+        print('Test String')
+        assert o.buf == 'Test String\n'
+
+    out, err = capfd.readouterr()
+    assert out == ''

--- a/girder_worker_utils/tests/tee_test.py
+++ b/girder_worker_utils/tests/tee_test.py
@@ -1,9 +1,10 @@
 import sys
 
-from girder_worker_utils.tee import TeeStdErr, TeeStdOut
+from girder_worker_utils.tee import Tee, tee_stdout, TeeStdErr, TeeStdOut
 
 
-class TeeCapture(TeeStdOut):
+@tee_stdout
+class TeeCapture(Tee):
     def __init__(self, *args, **kwargs):
         self.buf = ''
         super(TeeCapture, self).__init__(*args, **kwargs)


### PR DESCRIPTION
This implements a base class which can be subclassed for safe side-effect based actions to take on sys.stdout and sys.stderr.  It is motivated by the desire to replace the JobManager class's [stdout/stderr hijacking](https://github.com/girder/girder_worker/blob/master/girder_worker/utils.py#L100-L105).  This becomes problematic if the task also intends to hijack stdout/stderr (something that happens disturbingly often unfortunately).  As long as all parties are using Tee derived objects then all print() statements will be passed through (including to the original stdout/stderr). 

@zachmullen PTAL