### PR TITLE
Change transform/cleanup signatures to accept *args, **kwargs

### DIFF
--- a/girder_worker_utils/transform.py
+++ b/girder_worker_utils/transform.py
@@ -15,16 +15,16 @@ class Transform(object):
         """
         return str(self)
 
-    def cleanup(self):
+    def cleanup(self, *args, **kwargs):
         pass
 
     @abc.abstractmethod
-    def transform(self):
+    def transform(self, *args, **kwargs):
         pass
 
 
 @six.add_metaclass(abc.ABCMeta)
 class ResultTransform(Transform):
     @abc.abstractmethod
-    def transform(self, data):
+    def transform(self, data, *args, **kwargs):
         pass

--- a/girder_worker_utils/transforms/girder_io.py
+++ b/girder_worker_utils/transforms/girder_io.py
@@ -34,7 +34,7 @@ class GirderFileId(GirderClientTransform):
     def _repr_model_(self):
         return "{}('{}')".format(self.__class__.__name__, self.file_id)
 
-    def transform(self):
+    def transform(self, *args, **kwargs):
         self.file_path = os.path.join(
             tempfile.mkdtemp(), '{}'.format(self.file_id))
 
@@ -42,7 +42,7 @@ class GirderFileId(GirderClientTransform):
 
         return self.file_path
 
-    def cleanup(self):
+    def cleanup(self, *args, **kwargs):
         shutil.rmtree(os.path.dirname(self.file_path),
                       ignore_errors=True)
 
@@ -55,7 +55,7 @@ class GirderItemMetadata(GirderClientTransform):
     def _repr_model_(self):
         return "{}('{}')".format(self.__class__.__name__, self.item_id)
 
-    def transform(self, data):
+    def transform(self, data, *args, **kwargs):
         self.gc.addMetadataToItem(self.item_id, data)
 
         return data
@@ -71,7 +71,7 @@ class GirderUploadToItem(GirderClientResultTransform):
     def _repr_model_(self):
         return "{}('{}')".format(self.__class__.__name__, self.item_id)
 
-    def transform(self, path):
+    def transform(self, path, *args, **kwargs):
         self.output_file_path = path
         if os.path.isdir(path):
             for f in os.listdir(path):
@@ -82,7 +82,7 @@ class GirderUploadToItem(GirderClientResultTransform):
             self.gc.uploadFileToItem(self.item_id, path, **self.upload_kwargs)
         return self.item_id
 
-    def cleanup(self):
+    def cleanup(self, *args, **kwargs):
         if self.delete_file is True:
             if os.path.isdir(self.output_file_path):
                 shutil.rmtree(self.output_file_path)


### PR DESCRIPTION
Currently transforms are expected to act solely on the state defined
in their __init__ function.  While this provides a clean interface, it
may be too restrictive for some transforms (i.e. if a transform needs
access to the task object that is calling it).  Changing these
signatures now hedges against making breaking changes to the API after
there are a lot of these out in the wild.