### PR TITLE
Create job token by default

### DIFF
--- a/girder_worker_utils/transforms/girder_io.py
+++ b/girder_worker_utils/transforms/girder_io.py
@@ -35,7 +35,7 @@ class GirderClientTransform(Transform):
                     from girder.constants import TokenScope
                     from girder.models.token import Token
                     token = Token().createToken(
-                        days=1,
+                        days=7,
                         scope=[TokenScope.DATA_READ, TokenScope.DATA_WRITE],
                         user=getCurrentUser(),
                     )['_id']

--- a/girder_worker_utils/transforms/girder_io.py
+++ b/girder_worker_utils/transforms/girder_io.py
@@ -28,9 +28,21 @@ class GirderClientTransform(Transform):
                     # Fall back if the worker plugin is unavailble
                     except ImportError:
                         from girder.api.rest import getApiUrl as getWorkerApiUrl
-                from girder.api.rest import getCurrentToken
+
                 self.gc = GirderClient(apiUrl=getWorkerApiUrl())
-                self.gc.token = getCurrentToken()['_id']
+                from girder.api.rest import getCurrentUser
+                if getCurrentUser():
+                    from girder.constants import TokenScope
+                    from girder.models.token import Token
+                    token = Token().createToken(
+                        days=1,
+                        scope=[TokenScope.DATA_READ, TokenScope.DATA_WRITE],
+                        user=getCurrentUser(),
+                    )['_id']
+                else:
+                    from girder.api.rest import getCurrentToken
+                    token = getCurrentToken()['_id']
+                self.gc.token = token
             else:
                 self.gc = gc
         except ImportError:


### PR DESCRIPTION
closes #44

I looked at adding a test, but `gc=None` is not a condition that was ever tested before, so if we want to add that here I can look into it more.

Tested locally working.

Edit: notice in particular the scope restrictions.  I think these are safe, but I'm not positive.