### PR TITLE
Guard against missing temporary directory.

### DIFF
--- a/girder_worker_utils/transforms/common.py
+++ b/girder_worker_utils/transforms/common.py
@@ -16,4 +16,5 @@ class TemporaryDirectory(Transform):
         return self.temp_dir_path
 
     def cleanup(self):
-        shutil.rmtree(self.temp_dir_path, ignore_errors=True)
+        if hasattr(self, 'temp_dir_path'):
+            shutil.rmtree(self.temp_dir_path, ignore_errors=True)


### PR DESCRIPTION
Do not cleanup TemporaryDirectory if the transform never occurred.

This guards against seeing `AttributeError: 'TemporaryDirectory' object has no attribute 'temp_dir_path'`.