### PR TITLE
Allow the default girder client transform job scope to be changed

### DIFF
--- a/girder_worker_utils/transforms/girder_io.py
+++ b/girder_worker_utils/transforms/girder_io.py
@@ -10,7 +10,7 @@ from ..transform import ResultTransform, Transform
 
 
 class GirderClientTransform(Transform):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs):  # noqa
         gc = kwargs.pop('gc', None)
 
         try:
@@ -34,9 +34,17 @@ class GirderClientTransform(Transform):
                 if getCurrentUser():
                     from girder.constants import TokenScope
                     from girder.models.token import Token
+                    scope = [TokenScope.DATA_READ, TokenScope.DATA_WRITE]
+                    if 'GIRDER_WORKER_JOB_GC_SCOPE' in os.environ:
+                        try:
+                            scope = list({
+                                part.strip('"[\'] ') for part in
+                                os.environ['GIRDER_WORKER_JOB_GC_SCOPE'].split(',')} | set(scope))
+                        except Exception:
+                            pass
                     token = Token().createToken(
                         days=7,
-                        scope=[TokenScope.DATA_READ, TokenScope.DATA_WRITE],
+                        scope=scope,
                         user=getCurrentUser(),
                     )['_id']
                 else:

--- a/setup.py
+++ b/setup.py
@@ -13,9 +13,7 @@ def prerelease_local_scheme(version):
     (e.g. 0.0.0.dev<N>+g<HASH>) unless building on CircleCI for a
     pre-release in which case it ignores the hash and produces a
     PEP440 compliant pre-release version number (e.g. 0.0.0.dev<N>).
-
     """
-
     from setuptools_scm.version import get_local_node_and_date
 
     if 'CIRCLE_BRANCH' in os.environ and \
@@ -43,6 +41,8 @@ setup(
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
     ],
     install_requires=install_requires,
     python_requires='>=3.8',

--- a/tox.ini
+++ b/tox.ini
@@ -26,7 +26,7 @@ commands = pytest --cov=girder_worker_utils --cov-report html --cov-report term
 enable-extensions = C, D, E, F, I, N, W
 max-line-length = 100
 max-complexity = 10
-ignore = D100,D101,D102,D103,D104,D105,D107,D200,D204,D205,D400,W504
+ignore = D100,D101,D102,D103,D104,D105,D107,D200,D204,D205,D400,W504,B902
 import-order-style = google
 application-import-names = girder_worker_utils,gw_utils_demo_app
 


### PR DESCRIPTION
By default, if a girder client is created, it is created with `scope=[ TokenScope.DATA_READ, TokenScope.DATA_WRITE]` (`['core.data.read', 'core.data.write']`).  It can be desired to grant girder clients more scope than this.  If the environment variable `GIRDER_WORKER_JOB_GC_SCOPE` is specified, this is treated as a comma-separated list of scopes OR as a JSON encoded list of scope strings.  These are ADDED to the default scope.  That is, specifying
`GIRDER_WORKER_JOB_GC_SCOPE="jobs.rest.create_job"` will give the girder client read, write, and job creation privileges.